### PR TITLE
Added a compatibility flag for Arduino Every

### DIFF
--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -64,7 +64,7 @@ void SBUS::begin()
     _bus->begin(_sbusBaud,SERIAL_8E2);
   #elif defined(__AVR_ATmega2560__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)		// Arduino Mega 2560, 328P or 32u4
     _bus->begin(_sbusBaud, SERIAL_8E2);
-	#elif defined(ARDUINO_SAMD_ZERO)		// Adafruit Feather M0
+	#elif defined(ARDUINO_SAMD_ZERO)  || defined(__AVR_ARCH__)  // Adafruit Feather M0 || Arduino Nano Every
 		_bus->begin(_sbusBaud, SERIAL_8E2);
 	#else
 		#error unsupported device


### PR DESCRIPTION
The library works perfectly with the Arduino Nano Every, we just need to define this extra flag. Tested and proved here.